### PR TITLE
N°3422 - Show attachments metadata when choosing the one to send by email

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -39,8 +39,7 @@ function MakeAttachmentLabel($oOrmDoc, $sObjClass, $iObjId)
 	{
 		$sDictEntryCode .= '-with-timestamp';
 	}
-	$sAttachmentLabel = Dict::Format($sDictEntryCode, $sAttachmentLabel, $sNameUploader, $sTimeStampUpload);
-	$sAttachmentLabel .= ' - '.$sFileFormattedSize;
+	$sAttachmentLabel = Dict::Format($sDictEntryCode, $sFilenameForHtml, $sFileFormattedSize, $sNameUploader, $sTimeStampUpload);
 	return $sAttachmentLabel;
 }
 

--- a/ajax.php
+++ b/ajax.php
@@ -22,8 +22,8 @@ function MakeAttachmentLabel($oOrmDoc, $sObjClass, $iObjId)
 	$sTimeStampUpload = $oAttachment->Get('creation_date');
 	$sFileFormattedSize = $oOrmDoc->GetFormattedSize();
 	$sNameUploader = utils::HtmlEntities($oAttachment->Get('contact_id_friendlyname'));
-	$sAttachmentLabel = $oOrmDoc->GetFileName();
-	$sAttachmentLabel = utils::HtmlEntities($sAttachmentLabel);
+	$sFilename = $oOrmDoc->GetFileName();
+	$sFilenameForHtml = utils::HtmlEntities($sFilename);
 	$bHasUploaderName = $sNameUploader != '';
 	$bHasUploadTimestamp = $sTimeStampUpload != '';
 	$sDictEntryCode = 'UI-emry-attachment-label';

--- a/ajax.php
+++ b/ajax.php
@@ -16,6 +16,35 @@
 //   You should have received a copy of the GNU Affero General Public License
 //   along with iTop. If not, see <http://www.gnu.org/licenses/>
 
+function MakeAttachmentLabel($oOrmDoc, $sObjClass, $iObjId)
+{
+	$oAttachment = MetaModel::GetObject($sObjClass, $iObjId);
+	$sTimeStampUpload = $oAttachment->Get('creation_date');
+	$sFileFormattedSize = $oOrmDoc->GetFormattedSize();
+	$sNameUploader = utils::HtmlEntities($oAttachment->Get('contact_id_friendlyname'));
+	$sAttachmentLabel = $oOrmDoc->GetFileName();
+	$sAttachmentLabel = utils::HtmlEntities($sAttachmentLabel);
+	$bHasUploaderName = $sNameUploader != '';
+	$bHasUploadTimestamp = $sTimeStampUpload != '';
+	$sDictEntryCode = 'UI-emry-attachment-label';
+	if ($bHasUploaderName && $bHasUploadTimestamp)
+	{
+		$sDictEntryCode .= '-with-uploadername-and-timestamp';
+	}
+	elseif ($bHasUploaderName && !$bHasUploadTimestamp)
+	{
+		$sDictEntryCode .= '-with-uploadername';
+	}
+	elseif (!$bHasUploaderName && $bHasUploadTimestamp) 
+	{
+		$sDictEntryCode .= '-with-timestamp';
+	}
+	$sAttachmentLabel = Dict::Format($sDictEntryCode, $sAttachmentLabel, $sNameUploader, $sTimeStampUpload);
+	$sAttachmentLabel .= ' - '.$sFileFormattedSize;
+	return $sAttachmentLabel;
+}
+
+
 require_once(APPROOT.'/application/application.inc.php');
 
 //remove require itopdesignformat at the same time as version_compare(ITOP_DESIGN_LATEST_VERSION , '3.0') < 0
@@ -81,6 +110,7 @@ try
 				$oDoc = $oObj->Get($aData['sBlobAttCode']);
 				$sFileName = $oDoc->GetFileName();
 				$sIcon = utils::GetAbsoluteUrlAppRoot().AttachmentPlugIn::GetFileIcon($sFileName);
+				$sAttachmentLabel = MakeAttachmentLabel($oDoc, $sObjClass, $iObjId);
 				$sPreview = $oDoc->IsPreviewAvailable() ? 'true' : 'false';
 				$sChecked = ($aData['checked'] == 'true') ? ' checked' : '';
 				$sFileDef = $sObjClass.'::'.$iObjId.'/'.$aData['sBlobAttCode'];
@@ -92,7 +122,7 @@ try
 				if ($sPreview === 'true'){
 					$sPreviewData = utils::HtmlEntities('<img src="'.$sDownloadLink.'" style="max-width: '.$iMaxWidth.'"/>');
 				}
-				$oPage->add('<div style="vertical-align:middle;"><input type="checkbox" data-fileref="'.$sFileDef.'" id="'.$sId.'" '.$sChecked.'><label class="emry-attachment" data-preview="'.$sPreview.'" for="'.$sId.'" data-tooltip-html-enabled="true" data-tooltip-content="'.$sPreviewData.'">&nbsp;<img style="vertical-align:middle;" src="'.$sIcon.'" />&nbsp;'.htmlentities($sFileName, ENT_QUOTES, 'UTF-8').'</label></div>');
+				$oPage->add('<div style="vertical-align:middle;"><input type="checkbox" data-fileref="'.$sFileDef.'" id="'.$sId.'" '.$sChecked.'><label class="emry-attachment" data-preview="'.$sPreview.'" for="'.$sId.'" data-tooltip-html-enabled="true" data-tooltip-content="'.$sPreviewData.'">&nbsp;<img style="vertical-align:middle;" src="'.$sIcon.'" />&nbsp;'.$sAttachmentLabel.'</label></div>');
 				if(EmailReplyPlugIn::UseLegacy()) {
 					$oPage->add_ready_script(
 						<<<JS

--- a/ajax.php
+++ b/ajax.php
@@ -27,18 +27,8 @@ function MakeAttachmentLabel($oOrmDoc, $sObjClass, $iObjId)
 	$bHasUploaderName = $sNameUploader != '';
 	$bHasUploadTimestamp = $sTimeStampUpload != '';
 	$sDictEntryCode = 'UI-emry-attachment-label';
-	if ($bHasUploaderName && $bHasUploadTimestamp)
-	{
-		$sDictEntryCode .= '-with-uploadername-and-timestamp';
-	}
-	elseif ($bHasUploaderName && !$bHasUploadTimestamp)
-	{
-		$sDictEntryCode .= '-with-uploadername';
-	}
-	elseif (!$bHasUploaderName && $bHasUploadTimestamp) 
-	{
-		$sDictEntryCode .= '-with-timestamp';
-	}
+	$sDictEntryCode .= ($bHasUploaderName) ? '-with-uploadername' : '';
+	$sDictEntryCode .= ($bHasUploadTimestamp) ? '-with-timestamp' : '';
 	$sAttachmentLabel = Dict::Format($sDictEntryCode, $sFilenameForHtml, $sFileFormattedSize, $sNameUploader, $sTimeStampUpload);
 	return $sAttachmentLabel;
 }

--- a/de.dict.email-reply.php
+++ b/de.dict.email-reply.php
@@ -38,5 +38,9 @@ Dict::Add('DE DE', 'German', 'Deutsch', array(
 	'UI-emry-select-attachments:Short' => 'Anhänge...',
 	'UI-emry-attachments-to-be-sent' => 'Die folgenden Anhänge werden versandt:',
 	'UI-emry-select-attachments-tooltip' => 'Klicken Sie, um die zu sendenden Anhänge auszuwählen.',
+	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> von %2$s vom %3$s',
+	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> von %2$s',
+	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> vom %3$s',
+	'UI-emry-attachment-label' => '<b>%1$s</b>',
 ));
 

--- a/de.dict.email-reply.php
+++ b/de.dict.email-reply.php
@@ -38,7 +38,7 @@ Dict::Add('DE DE', 'German', 'Deutsch', array(
 	'UI-emry-select-attachments:Short' => 'Anhänge...',
 	'UI-emry-attachments-to-be-sent' => 'Die folgenden Anhänge werden versandt:',
 	'UI-emry-select-attachments-tooltip' => 'Klicken Sie, um die zu sendenden Anhänge auszuwählen.',
-	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> von %3$s vom %4$s - %2$s',
+	'UI-emry-attachment-label-with-uploadername-with-timestamp' => '<b>%1$s</b> von %3$s vom %4$s - %2$s',
 	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> von %3$s - %2$s',
 	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> vom %4$s - %2$s',
 	'UI-emry-attachment-label' => '<b>%1$s</b> - %2$s',

--- a/de.dict.email-reply.php
+++ b/de.dict.email-reply.php
@@ -38,9 +38,9 @@ Dict::Add('DE DE', 'German', 'Deutsch', array(
 	'UI-emry-select-attachments:Short' => 'Anhänge...',
 	'UI-emry-attachments-to-be-sent' => 'Die folgenden Anhänge werden versandt:',
 	'UI-emry-select-attachments-tooltip' => 'Klicken Sie, um die zu sendenden Anhänge auszuwählen.',
-	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> von %2$s vom %3$s',
-	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> von %2$s',
-	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> vom %3$s',
-	'UI-emry-attachment-label' => '<b>%1$s</b>',
+	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> von %3$s vom %4$s - %2$s',
+	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> von %3$s - %2$s',
+	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> vom %4$s - %2$s',
+	'UI-emry-attachment-label' => '<b>%1$s</b> - %2$s',
 ));
 

--- a/email-reply.js
+++ b/email-reply.js
@@ -132,7 +132,9 @@ function EmailReplySelectAttachments(sCaseLogAttCode)
 	$('body').append(oDlg);
 	oDlg.dialog({
 		modal:true,
-		width: 500,
+		width: '70%',
+		minWidth: 'auto',
+		maxWidth: '90%',
 		height: 'auto',
 		maxHeight: $(window).height()*0.9,
 		title: Dict.S('UI-emry-select-attachments'),

--- a/en.dict.email-reply.php
+++ b/en.dict.email-reply.php
@@ -39,5 +39,9 @@ Dict::Add('EN US', 'English', 'English', array(
 	'UI-emry-select-attachments:Short' => 'Attachments',
 	'UI-emry-attachments-to-be-sent' => 'The following attachments will be sent:',
 	'UI-emry-select-attachments-tooltip' => 'Click to select the attachments to be sent',
+	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> by %2$s at %3$s',
+	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> by %2$s',
+	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> at %3$s',
+	'UI-emry-attachment-label' => '<b>%1$s</b>',
 ));
 

--- a/en.dict.email-reply.php
+++ b/en.dict.email-reply.php
@@ -39,9 +39,9 @@ Dict::Add('EN US', 'English', 'English', array(
 	'UI-emry-select-attachments:Short' => 'Attachments',
 	'UI-emry-attachments-to-be-sent' => 'The following attachments will be sent:',
 	'UI-emry-select-attachments-tooltip' => 'Click to select the attachments to be sent',
-	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> by %2$s at %3$s',
-	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> by %2$s',
-	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> at %3$s',
-	'UI-emry-attachment-label' => '<b>%1$s</b>',
+	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> by %3$s at %4$s - %2$s',
+	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> by %3$s - %2$s',
+	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> at %4$s - %2$s',
+	'UI-emry-attachment-label' => '<b>%1$s</b> - %2$s',
 ));
 

--- a/en.dict.email-reply.php
+++ b/en.dict.email-reply.php
@@ -39,7 +39,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'UI-emry-select-attachments:Short' => 'Attachments',
 	'UI-emry-attachments-to-be-sent' => 'The following attachments will be sent:',
 	'UI-emry-select-attachments-tooltip' => 'Click to select the attachments to be sent',
-	'UI-emry-attachment-label-with-uploadername-and-timestamp' => '<b>%1$s</b> by %3$s at %4$s - %2$s',
+	'UI-emry-attachment-label-with-uploadername-with-timestamp' => '<b>%1$s</b> by %3$s at %4$s - %2$s',
 	'UI-emry-attachment-label-with-uploadername' => '<b>%1$s</b> by %3$s - %2$s',
 	'UI-emry-attachment-label-with-timestamp' => '<b>%1$s</b> at %4$s - %2$s',
 	'UI-emry-attachment-label' => '<b>%1$s</b> - %2$s',


### PR DESCRIPTION
Hi Combodo!

### Summary ###
This PR adds more info about the file one is about to choose to attach to a notification-mail. Namely the uploaders name (if given), the time, when it was uploaded (if given), and the filesize.

### Screenshots ###
- This is how it renders in an "optimal" case (all info given, no extraordinary long names and so on):
![image](https://user-images.githubusercontent.com/21227916/213553460-11d819cd-1018-47f6-9216-b9a088221fa6.png)

- This is how it renders in a case, where the filenames are too long/the viewport is too small:
![image](https://user-images.githubusercontent.com/21227916/213553560-3d60a6b0-d79c-4e9a-ad82-e801a3232252.png)

- This is how it renders, if the uploaders name isn't given (note the autoshrinking and no unncessary stuff is rendered):
![image](https://user-images.githubusercontent.com/21227916/213553841-020bd28b-9828-4802-a690-f410b7999da2.png)

- This is how it renders, if the timestamp isn't given (note the autoshrinking and no unncessary stuff is rendered):
![image](https://user-images.githubusercontent.com/21227916/213553919-05922def-4261-4870-b901-9cc854ba2eef.png)

### Notes ###
- Tested on Firefox and Chrome.
- There a few cases, where the timestamp or the person on an attachment aren't recorded correctly. In this case, they are not displayed.
- The resulting filenamestring can be rather long, that's why I opted to fatten the filename itself.
- This is the reason for using `utils::HtmlEntities()` on the filename itself and on the persons name (omitting timestamp and filesize, since they are calculated serverside and can't be edited later on) and then removing `htmlentitites()` in line 105 of ajax.php for the filename. I don't know, if it's good practice to escape the timestamp and filesize aswell. Feel free to add it, if needed.
- Since I want the strings to be as short as possible, I opted to not use the Dicts `Attachments:File:Date` and `Attachments:File:Uploader`, since they are rather long in some languages, but instead created new entries within the Extension for the little words `by` and `at` (and I hope, there are short equivalents in nearly all languages).
- When creating the modal, I changed the definitions for `width`, `maxWidth` and `minWidth` to be all relative now. The behavior is (or better: should be; I am no expert on CSS whatsoever): (a) Make the modal as small as possible without linebreaks, (b) but only grow it to 90% of the viewports(?) width and (c) make it not indefinitely small.

Martin